### PR TITLE
Add refresh_token to SBX marketplace grant types

### DIFF
--- a/sbx/trusted_services_list.yaml
+++ b/sbx/trusted_services_list.yaml
@@ -4,7 +4,7 @@ clients:
     redirectUris: ["https://dome-marketplace-sbx.org/auth/vc/callback"]
     scopes: ["openid_learcredential"]
     clientAuthenticationMethods: ["client_secret_jwt"]
-    authorizationGrantTypes: ["authorization_code"]
+    authorizationGrantTypes: ["authorization_code", "refresh_token"]
     postLogoutRedirectUris: ["https://dome-marketplace-sbx.org/"]
     requireAuthorizationConsent: false
     requireProofKey: false


### PR DESCRIPTION
This PR adds the refresh_token as an authorized grant type for the Marketplace portal in SBX