### PR TITLE
Update trusted_access_nodes_list.yaml New versions test

### DIFF
--- a/dev/trusted_access_nodes_list.yaml
+++ b/dev/trusted_access_nodes_list.yaml
@@ -1,6 +1,6 @@
 organizations:
   - name: DOME
-    dlt_address: 0x6CAe2e4907aD7fee38cC9eC2449595D2978E8Aa5
+    dlt_address: 0x6CAe2e4907aD7fee38cC9eC2449595D2978E8Aa52
 
   - name: QA
-    dlt_address: 0xd06CB807734b52C7BDAAD2ac73c7a25656d4f5Aa
+    dlt_address: 0xd06CB807734b52C7BDAAD2ac73c7a25656d4f5Aa2


### PR DESCRIPTION
Testing new version of Access Node (0.9.3), which includes Desmos version 1.1.3.